### PR TITLE
ci: disable Linux sandbox to fix brew doctor failure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,12 @@ jobs:
           - macos-15
           - macos-14
     runs-on: ${{ matrix.os }}
+    env:
+      # Ubuntu 24.04 GitHub runners restrict unprivileged user namespaces,
+      # which breaks rootless bwrap and makes `brew doctor` (run during
+      # `brew test-bot --only-setup`) fail with a missing Bubblewrap error.
+      # Disable the Linux sandbox as recommended by Homebrew. No-op on macOS.
+      HOMEBREW_NO_SANDBOX_LINUX: 1
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew


### PR DESCRIPTION
## What

CI was failing at the `brew test-bot --only-setup` step (e.g. [this run](https://github.com/iopsystems/homebrew-iop/actions/runs/26913915641/job/79398844815)). Despite looking like a deps error, the actual failure is environmental:

```
==> brew doctor
==> FAILED
Bubblewrap is required to use the Linux sandbox but was not found.
...
As a final workaround, disable the Linux sandbox:
  export HOMEBREW_NO_SANDBOX_LINUX=1
Error: 1 failed step!
brew doctor
```

## Why

Recent Homebrew versions enable a Linux sandbox that requires a rootless `bwrap` (Bubblewrap). Ubuntu 24.04 GitHub runners restrict unprivileged user namespaces (via AppArmor), so rootless `bwrap` is unavailable and `brew doctor` — run during `--only-setup` — fails the whole job.

## Fix

Set `HOMEBREW_NO_SANDBOX_LINUX=1` at the `test-bot` job level, the workaround recommended directly in Homebrew's error output. It's a no-op on the macOS runners.

https://claude.ai/code/session_01AyS1SPHTAKccGHFCqQHZv4

---
_Generated by [Claude Code](https://claude.ai/code/session_01AyS1SPHTAKccGHFCqQHZv4)_