### PR TITLE
systemslab 152.0.0

### DIFF
--- a/Formula/systemslab.rb
+++ b/Formula/systemslab.rb
@@ -11,8 +11,8 @@ class Systemslab < Formula
   homepage  "https://iop.systems"
   url       "https://github.com/iopsystems/systemslab.git",
     using:    SystemsLabDownloadStrategy,
-    tag:      "v149.0.0",
-    revision: "5a3f09fb117e0ec7750da9393add8ff771f5c412"
+    tag:      "v152.0.0",
+    revision: "15cd881bcd79c9800d37d5b40e30f1e0c5a9a26d"
   license   :cannot_represent
 
   bottle do


### PR DESCRIPTION
Replaces #98 with a rebased, merge-commit-free branch.

`brew pr-pull` cherry-picks each commit in a PR and cannot handle merge commits. The original #98 branch had a `main`→branch merge commit (introduced by GitHub's "Update branch"), which made the `brew pr-pull` publish step fail:

```
error: commit 825c131a... is a merge but no -m option was given.
fatal: cherry-pick failed
```

This branch is the same `systemslab 152.0.0` bump rebased cleanly on top of current `main` (which now includes the CI sandbox fix), so it has linear history and `brew pr-pull` will succeed.

Supersedes #96 (150.0.0) and #97 (151.0.0) as well — 152.0.0 is the latest.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AyS1SPHTAKccGHFCqQHZv4)_