### PR TITLE
ci: pin Homebrew/actions references to @main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,10 +14,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
 
       - name: Set up git
-        uses: Homebrew/actions/git-user-config@master
+        uses: Homebrew/actions/git-user-config@main
 
       - name: Pull bottles
         env:
@@ -26,7 +26,7 @@ jobs:
         run: brew pr-pull --debug --tap="$GITHUB_REPOSITORY" "$PULL_REQUEST"
 
       - name: Push commits
-        uses: Homebrew/actions/git-try-push@master
+        uses: Homebrew/actions/git-try-push@main
         with:
           token: ${{ github.token }}
           branch: main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
         with:
           token: ${{ secrets.API_TOKEN }}
 


### PR DESCRIPTION
## What

Updates all `Homebrew/actions/*` references in the CI workflows from `@master` to `@main`.

Affected references:
- `tests.yml`: `setup-homebrew@master` → `@main`
- `publish.yml`: `setup-homebrew@master`, `git-user-config@master`, `git-try-push@master` → `@main`

## Why

CI logs surface this deprecation warning:

> `Homebrew/actions/git-try-push@master` is deprecated. Please update your workflow references to use `Homebrew/actions/git-try-push@main`. The "master" branch sync will stop and this warning will become an error when Homebrew 5.2.0 is released (no earlier than 2026-06-10).

The deprecation applies to the whole `Homebrew/actions` repo (the `master` branch sync is being retired), so this also updates `setup-homebrew` and `git-user-config`, not just `git-try-push`, to avoid the warning becoming a hard error once Homebrew 5.2.0 ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JyypBcj1WdJGHqKKhGzBDm)_