### PR TITLE
skills-mcp: add formula

### DIFF
--- a/Formula/skills-mcp.rb
+++ b/Formula/skills-mcp.rb
@@ -7,7 +7,6 @@ class SkillsMcp < Formula
   # `brew pr-pull` fills in the `bottle do` block below on publish.
   url "https://github.com/iopsystems/skills-mcp.git",
     tag: "v0.1.0"
-  version "0.1.0"
   license any_of: ["Apache-2.0", "MIT"]
 
   depends_on "rust" => :build

--- a/Formula/skills-mcp.rb
+++ b/Formula/skills-mcp.rb
@@ -1,0 +1,39 @@
+# Brew formula for skills-mcp, the MCP server for embedded agent skills.
+
+class SkillsMcp < Formula
+  desc "MCP server for embedded agent skills and workflows over stdio"
+  homepage "https://github.com/iopsystems/skills-mcp"
+  # Built from the tagged source. `brew test-bot` produces the bottles and
+  # `brew pr-pull` fills in the `bottle do` block below on publish.
+  url "https://github.com/iopsystems/skills-mcp.git",
+    tag: "v0.1.0"
+  version "0.1.0"
+  license any_of: ["Apache-2.0", "MIT"]
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    require "json"
+
+    request = {
+      jsonrpc: "2.0",
+      id:      1,
+      method:  "initialize",
+      params:  {
+        protocolVersion: "2025-03-26",
+        capabilities:    {},
+        clientInfo:      { name: "brew-test", version: "0.1.0" },
+      },
+    }.to_json
+
+    # skills-mcp is an MCP stdio server, not a flag-oriented CLI: it answers a
+    # single `initialize` request on stdin and exits when stdin closes. The
+    # server identifies itself by its package name in the response.
+    output = pipe_output("#{bin}/skills-mcp", "#{request}\n")
+    assert_match "skills-mcp", output
+  end
+end


### PR DESCRIPTION
## Summary

Adds `Formula/skills-mcp.rb` for [skills-mcp](https://github.com/iopsystems/skills-mcp), the MCP server for embedded agent skills and workflows.

Like the other Rust formulae in this tap, it builds from source with `cargo install` so `brew test-bot` produces the bottles and `brew pr-pull` attaches them. The source is pinned to the `v0.1.0` git tag. Because skills-mcp is an MCP **stdio** server (not a flag CLI), the `test do` block drives it with a JSON-RPC `initialize` request on stdin and asserts the server names itself in the response.

## ⚠️ Blocked on the skills-mcp v0.1.0 release

The `v0.1.0` tag does not exist yet — it's created by the companion PR [iopsystems/skills-mcp#13](https://github.com/iopsystems/skills-mcp/pull/13), which renames the crate to `skills-mcp` and adds the release workflow. **`brew test-bot` on this PR will stay red until that tag is published.** Sequence:

1. Merge skills-mcp#13 to `main`.
2. In skills-mcp, `git tag v0.1.0 && git push origin v0.1.0` (its release workflow cuts the GitHub Release).
3. Re-run CI on this PR. `brew test-bot` will then clone the `v0.1.0` tag, build the bottles, and the tap's `autotag` → `pr-pull` flow publishes them.

The url is intentionally **tag-only** (no pinned `revision:`): the tag's commit is only knowable once step 2 happens, so tag-only lets the formula become correct automatically rather than shipping a guessed SHA. A `revision:` can be pinned afterward for reproducibility if desired.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AgWy8CEeT7ZuWQLaVVG5NC)_