### PR TITLE
skills-mcp: automate formula updates on new releases

### DIFF
--- a/.github/workflows/update-skills-mcp.yml
+++ b/.github/workflows/update-skills-mcp.yml
@@ -1,0 +1,68 @@
+name: Update skills-mcp Formula
+
+on:
+  # Check for new releases daily at 08:15 UTC, offset from the Rezolus check so
+  # the two updaters do not open pull requests in the same minute.
+  schedule:
+    - cron: "15 8 * * *"
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for new skills-mcp release
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Get the latest release tag from iopsystems/skills-mcp
+          LATEST=$(gh api repos/iopsystems/skills-mcp/releases/latest --jq '.tag_name')
+          echo "latest_tag=$LATEST" >> "$GITHUB_OUTPUT"
+
+          # Extract version without the leading 'v'
+          LATEST_VERSION="${LATEST#v}"
+          echo "latest_version=$LATEST_VERSION" >> "$GITHUB_OUTPUT"
+
+          # skills-mcp.rb builds from a git tag rather than a source tarball, so
+          # the current version lives in the `tag:` argument and there is no
+          # source checksum to recompute.
+          CURRENT_VERSION=$(grep -oP '^\s*tag: "v\K[0-9]+\.[0-9]+\.[0-9]+' Formula/skills-mcp.rb)
+          echo "current_version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+
+          if [ "$LATEST_VERSION" = "$CURRENT_VERSION" ]; then
+            echo "up_to_date=true" >> "$GITHUB_OUTPUT"
+            echo "Formula is already up to date (v$CURRENT_VERSION)"
+          else
+            echo "up_to_date=false" >> "$GITHUB_OUTPUT"
+            echo "New version available: v$CURRENT_VERSION -> v$LATEST_VERSION"
+          fi
+
+      - name: Update formula
+        if: steps.check.outputs.up_to_date == 'false'
+        env:
+          LATEST_TAG: ${{ steps.check.outputs.latest_tag }}
+          CURRENT_VERSION: ${{ steps.check.outputs.current_version }}
+        run: |
+          # Point the formula at the new tag. The stale `bottle do` block is
+          # left alone on purpose: `brew test-bot` rebuilds the bottles for this
+          # pull request and `brew pr-pull` rewrites the block from them.
+          sed -i "s|tag: \"v${CURRENT_VERSION}\"|tag: \"${LATEST_TAG}\"|" Formula/skills-mcp.rb
+          grep -n 'tag:' Formula/skills-mcp.rb
+
+      - name: Create pull request
+        if: steps.check.outputs.up_to_date == 'false'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.API_TOKEN }}
+          commit-message: "skills-mcp: update to ${{ steps.check.outputs.latest_version }}"
+          branch: update-skills-mcp-${{ steps.check.outputs.latest_version }}
+          title: "skills-mcp: update to ${{ steps.check.outputs.latest_version }}"
+          body: |
+            Automated update of the skills-mcp formula to [${{ steps.check.outputs.latest_tag }}](https://github.com/iopsystems/skills-mcp/releases/tag/${{ steps.check.outputs.latest_tag }}).
+          delete-branch: true


### PR DESCRIPTION
Adds `update-skills-mcp.yml`, the missing link in an otherwise fully automated chain.

## Why

Everything downstream of a formula PR already runs itself:

- `tests.yml` runs `brew test-bot --only-formulae` on PRs, uploads bottles, and applies the `pr-pull` label once tests pass;
- `publish.yml` reacts to that label with `brew pr-pull` and pushes to `main`.

The only manual step for `skills-mcp` was **opening** the PR — and it shows. The formula still points at `v0.1.0` while upstream `main` is 39 commits ahead, carrying four skills (`architecture-diagram`, `dataflow-diagram`, `sweep-comments`, `technical-prose`) that have never reached a `brew install` user. `update-rezolus.yml` already solves exactly this for the other formula.

## What it does

Mirrors `update-rezolus.yml`: daily cron plus `workflow_dispatch`, compares the tap's formula version against `iopsystems/skills-mcp` latest release, opens a PR via `peter-evans/create-pull-request` with the existing `API_TOKEN` secret. Cron is offset to 08:15 UTC so the two updaters don't open PRs in the same minute.

## The one adaptation

The two formulae differ in how they fetch source:

```ruby
# rezolus.rb — source tarball, checksummed
url "https://github.com/iopsystems/rezolus/archive/refs/tags/v5.17.0.tar.gz"
sha256 "d2964e..."

# skills-mcp.rb — git tag, no source checksum
url "https://github.com/iopsystems/skills-mcp.git",
  tag: "v0.1.0"
```

So this updater rewrites the `tag:` argument and has no `sha256` to recompute — strictly simpler than the rezolus sed. The stale `bottle do` block is deliberately left untouched, same as the rezolus updater, since `brew pr-pull` rewrites it from the bottles `test-bot` produced.

## Verification

Version detection and the rewrite were run against the current `Formula/skills-mcp.rb` before commit:

```
detected current: '0.1.0'
9c9
<     tag: "v0.1.0"
---
>     tag: "v0.2.0"
```

YAML parses; one job, four steps.

Once merged I'll `workflow_dispatch` it against the upcoming `skills-mcp` v0.2.0 tag, so the formula bump that reaches users is machine-generated rather than hand-edited — which is the actual point of the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)