### PR TITLE
skills-mcp: update to 0.2.0

### DIFF
--- a/Formula/skills-mcp.rb
+++ b/Formula/skills-mcp.rb
@@ -6,7 +6,7 @@ class SkillsMcp < Formula
   # Built from the tagged source. `brew test-bot` produces the bottles and
   # `brew pr-pull` fills in the `bottle do` block below on publish.
   url "https://github.com/iopsystems/skills-mcp.git",
-    tag: "v0.1.0"
+    tag: "v0.2.0"
   license any_of: ["Apache-2.0", "MIT"]
 
   bottle do


### PR DESCRIPTION
Automated update of the skills-mcp formula to [v0.2.0](https://github.com/iopsystems/skills-mcp/releases/tag/v0.2.0).